### PR TITLE
Rework Common Entity representation

### DIFF
--- a/FuncGameDev/FSharp/Data/CommonEntityData.fs
+++ b/FuncGameDev/FSharp/Data/CommonEntityData.fs
@@ -2,4 +2,5 @@
 
 type T = { id: int;
            position: float * float;
-           speed: int }
+           speed: int;
+           entity: EntityType.T }

--- a/FuncGameDev/FSharp/Data/EnemyData.fs
+++ b/FuncGameDev/FSharp/Data/EnemyData.fs
@@ -1,6 +1,5 @@
 ﻿module EnemyData
 
-type T = { ced: CommonEntityData.T;
-           health: int; 
+type T = { health: int; 
            weapon: WeaponData.T; 
            effects: EffectData.T list }

--- a/FuncGameDev/FSharp/Data/EntityType.fs
+++ b/FuncGameDev/FSharp/Data/EntityType.fs
@@ -1,0 +1,8 @@
+﻿module EntityType
+
+type T =
+    | Player of PlayerData.T
+    | Enemy of EnemyData.T
+    | Item of ItemData.T
+    | Weapon of WeaponData.T
+    | Projectile of ProjectileData.T

--- a/FuncGameDev/FSharp/Data/GameState.fs
+++ b/FuncGameDev/FSharp/Data/GameState.fs
@@ -6,3 +6,18 @@ type T = {
     gamedata: GameData.T;
     nextid: int // the next created entity will have this id
 }
+
+let mutable instance: T = {
+    entities = Map.empty;
+    level = {
+        LevelData.grid = Array2D.zeroCreate 0 0;
+        LevelData.size = (0,0);
+        LevelData.startpos = (0,0);
+        LevelData.stairpos = (0,0)
+    };
+    gamedata = {
+        GameData.time = 60.0;
+        GameData.floor = 0
+    };
+    nextid = 1
+}

--- a/FuncGameDev/FSharp/Data/GameState.fs
+++ b/FuncGameDev/FSharp/Data/GameState.fs
@@ -1,12 +1,8 @@
 ﻿module GameState
 
 type T = {
-    players: PlayerData.T list;
-    enemies: EnemyData.T list;
-    weapons: WeaponData.T list;
-    items: ItemData.T list;
-    projectiles: ProjectileData.T list;
+    entities : Collections.Map<int, CommonEntityData.T>; // map from id to entity
     level: LevelData.T;
     gamedata: GameData.T;
-    id: int // the next created entity will have this id
+    nextid: int // the next created entity will have this id
 }

--- a/FuncGameDev/FSharp/Data/ItemData.fs
+++ b/FuncGameDev/FSharp/Data/ItemData.fs
@@ -1,3 +1,3 @@
 ﻿module ItemData
 
-type T = { ced: CommonEntityData.T }
+type T = { itemName: string }

--- a/FuncGameDev/FSharp/Data/LevelData.fs
+++ b/FuncGameDev/FSharp/Data/LevelData.fs
@@ -1,6 +1,6 @@
 ﻿module LevelData
 
-type T = { grid: int list list; 
+type T = { grid: int[,]; 
            size: int * int; 
            startpos: int * int; 
            stairpos: int * int }

--- a/FuncGameDev/FSharp/Data/PlayerData.fs
+++ b/FuncGameDev/FSharp/Data/PlayerData.fs
@@ -1,7 +1,6 @@
 ﻿module PlayerData
 
-type T = { ced: CommonEntityData.T;
-           melee: WeaponData.T; 
+type T = { melee: WeaponData.T; 
            ranged: WeaponData.T; 
            roll: WeaponData.T; 
            active: WeaponData.T; 

--- a/FuncGameDev/FSharp/Data/ProjectileData.fs
+++ b/FuncGameDev/FSharp/Data/ProjectileData.fs
@@ -1,5 +1,4 @@
 ﻿module ProjectileData
 
-type T = { ced: CommonEntityData.T;
-           damage: int; 
+type T = { damage: int; 
            effects: EffectData.T list; }

--- a/FuncGameDev/FSharp/Data/WeaponData.fs
+++ b/FuncGameDev/FSharp/Data/WeaponData.fs
@@ -1,7 +1,13 @@
 ﻿module WeaponData
 
-type T = { ced: CommonEntityData.T;
+type Category =
+    | Melee
+    | Ranged
+    | Roll
+    | Active
+
+type T = { weaponName: string;
            cooldown: float; 
            damage: int; 
            effects: EffectData.T list; 
-           weaponType: string }
+           weaponType: Category }

--- a/FuncGameDev/FSharp/FSharp.fsproj
+++ b/FuncGameDev/FSharp/FSharp.fsproj
@@ -17,7 +17,6 @@
     <Compile Include="Behavior\ItemBehavior.fs" />
     <Compile Include="Behavior\PlayerBehavior.fs" />
     <Compile Include="Behavior\EnemyBehavior.fs" />
-    <Compile Include="Data\CommonEntityData.fs" />
     <Compile Include="Data\EffectData.fs" />
     <Compile Include="Data\WeaponData.fs" />
     <Compile Include="Data\EnemyData.fs" />
@@ -26,6 +25,8 @@
     <Compile Include="Data\LevelData.fs" />
     <Compile Include="Data\PlayerData.fs" />
     <Compile Include="Data\ProjectileData.fs" />
+    <Compile Include="Data\EntityType.fs" />
+    <Compile Include="Data\CommonEntityData.fs" />
     <Compile Include="Data\GameState.fs" />
     <Compile Include="Interpretation\StateManager.fs" />
     <Compile Include="Interpretation\ControlModel.fs" />
@@ -33,6 +34,7 @@
     <Compile Include="Unity\PlayerUpdater.fs" />
     <Compile Include="Services\InputConfigurationService.fs" />
     <Compile Include="Unity\UserController.fs" />
+    <Compile Include="Test\TestGameState.fs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/FuncGameDev/FSharp/Test/TestGameState.fs
+++ b/FuncGameDev/FSharp/Test/TestGameState.fs
@@ -1,0 +1,88 @@
+﻿module TestGameState
+
+let testMelee = {
+    WeaponData.weaponName = "Test Melee Weapon";
+    WeaponData.cooldown = 0.4;
+    WeaponData.damage = 35;
+    WeaponData.effects = [];
+    WeaponData.weaponType = WeaponData.Category.Melee;
+}
+
+let testRanged = {
+    WeaponData.weaponName = "Test Ranged Weapon";
+    WeaponData.cooldown = 0.1;
+    WeaponData.damage = 5;
+    WeaponData.effects = [];
+    WeaponData.weaponType = WeaponData.Category.Ranged;
+}
+
+let testRoll = {
+    WeaponData.weaponName = "Test Roll Weapon";
+    WeaponData.cooldown = 1.0;
+    WeaponData.damage = 0;
+    WeaponData.effects = [];
+    WeaponData.weaponType = WeaponData.Category.Roll;
+}
+
+let testActive = {
+    WeaponData.weaponName = "Test Active Weapon";
+    WeaponData.cooldown = 10.0;
+    WeaponData.damage = 125;
+    WeaponData.effects = [];
+    WeaponData.weaponType = WeaponData.Category.Active;
+}
+
+let testPlayer = {
+    CommonEntityData.id = 1;
+    CommonEntityData.position = (150.0,250.0);
+    CommonEntityData.speed = 10;
+    CommonEntityData.entity = EntityType.Player {
+        melee = testMelee;
+        ranged = testRanged;
+        roll = testRoll;
+        active = testActive;
+        items = [];
+        effects = []
+    }
+}
+
+let testEnemy1 = {
+    CommonEntityData.id = 2;
+    CommonEntityData.position = (250.0,250.0);
+    CommonEntityData.speed = 3;
+    CommonEntityData.entity = EntityType.Enemy {
+        health = 100;
+        weapon = testMelee;
+        effects = []
+    }
+}
+
+let testEnemy2 = {
+    CommonEntityData.id = 3;
+    CommonEntityData.position = (150.0,150.0);
+    CommonEntityData.speed = 4;
+    CommonEntityData.entity = EntityType.Enemy {
+        health = 100;
+        weapon = testMelee;
+        effects = []
+    }
+}
+
+let testLevel = {
+    LevelData.grid = Array2D.zeroCreate 20 20;
+    LevelData.size = (20,20);
+    LevelData.startpos = (5,5);
+    LevelData.stairpos = (15,15)
+}
+
+let testGameData = {
+    GameData.time = 60.0;
+    GameData.floor = 0
+}
+
+let testGameState = {
+    GameState.entities = Map.ofList[(1, testPlayer); (2, testEnemy1); (3, testEnemy2)];
+    GameState.level = testLevel;
+    GameState.gamedata = testGameData;
+    GameState.nextid = 4
+}


### PR DESCRIPTION
Instead of each different entity type having a CommonEntityData, the CommonEntityData now has the individual entity types. Distinguishing between entity types is done using a discriminated union. This commit also includes an example GameState for reference purposes.